### PR TITLE
Adding support for approvals inside jobs

### DIFF
--- a/api-job/src/main/java/org/azbuilder/api/schedule/JobService.java
+++ b/api-job/src/main/java/org/azbuilder/api/schedule/JobService.java
@@ -11,7 +11,6 @@ import org.azbuilder.api.client.model.organization.workspace.variable.Variable;
 import org.azbuilder.api.client.model.response.ResponseWithInclude;
 import org.azbuilder.api.schedule.executor.ExecutorJob;
 import org.azbuilder.api.schedule.yaml.Flow;
-import org.azbuilder.api.schedule.yaml.FlowType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;

--- a/api-job/src/main/java/org/azbuilder/api/schedule/JobService.java
+++ b/api-job/src/main/java/org/azbuilder/api/schedule/JobService.java
@@ -11,6 +11,7 @@ import org.azbuilder.api.client.model.organization.workspace.variable.Variable;
 import org.azbuilder.api.client.model.response.ResponseWithInclude;
 import org.azbuilder.api.schedule.executor.ExecutorJob;
 import org.azbuilder.api.schedule.yaml.Flow;
+import org.azbuilder.api.schedule.yaml.FlowType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
@@ -80,8 +81,25 @@ public class JobService {
         return sendToExecutor(job, executorJob);
     }
 
+    public void requireJobApproval(Job job, String newStatus, String approvalTeam) {
+        JobRequest jobRequest = new JobRequest();
+        job.getAttributes().setStatus(newStatus);
+        //job.getAttributes().setApprovalTeam(approvalTeam);
+        jobRequest.setData(job);
+        terrakubeClient.updateJob(jobRequest, job.getRelationships().getOrganization().getData().getId(), job.getId());
+    }
+
     public List<Job> searchPendingJobs() {
         ResponseWithInclude<List<Organization>, Job> organizationJobList = terrakubeClient.getAllOrganizationsWithJobStatus("pending");
+
+        if (!organizationJobList.getData().isEmpty() && organizationJobList.getIncluded() != null)
+            return organizationJobList.getIncluded();
+        else
+            return new ArrayList<>();
+    }
+
+    public List<Job> searchApprovedJobs() {
+        ResponseWithInclude<List<Organization>, Job> organizationJobList = terrakubeClient.getAllOrganizationsWithJobStatus("approved");
 
         if (!organizationJobList.getData().isEmpty() && organizationJobList.getIncluded() != null)
             return organizationJobList.getIncluded();

--- a/api-job/src/main/java/org/azbuilder/api/schedule/yaml/Flow.java
+++ b/api-job/src/main/java/org/azbuilder/api/schedule/yaml/Flow.java
@@ -11,6 +11,7 @@ import java.util.List;
 @Setter
 public class Flow {
     private String type;
+    private String team;
     private int step;
     List<Command> commands;
 }

--- a/api-job/src/main/java/org/azbuilder/api/schedule/yaml/FlowType.java
+++ b/api-job/src/main/java/org/azbuilder/api/schedule/yaml/FlowType.java
@@ -1,0 +1,9 @@
+package org.azbuilder.api.schedule.yaml;
+
+public enum FlowType {
+    terraformPlan,
+    terraformApply,
+    terraformDestroy,
+    customScripts,
+    approval
+}

--- a/api/src/main/java/org/azbuilder/api/rs/checks/job/TeamApproveJob.java
+++ b/api/src/main/java/org/azbuilder/api/rs/checks/job/TeamApproveJob.java
@@ -1,0 +1,37 @@
+package org.azbuilder.api.rs.checks.job;
+
+import com.yahoo.elide.annotation.SecurityCheck;
+import com.yahoo.elide.core.security.ChangeSpec;
+import com.yahoo.elide.core.security.RequestScope;
+import com.yahoo.elide.core.security.checks.OperationCheck;
+import lombok.extern.slf4j.Slf4j;
+import org.azbuilder.api.plugin.security.groups.GroupService;
+import org.azbuilder.api.plugin.security.user.AuthenticatedUser;
+import org.azbuilder.api.rs.job.Job;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Optional;
+
+@Slf4j
+@SecurityCheck(TeamApproveJob.RULE)
+public class TeamApproveJob extends OperationCheck<Job> {
+    public static final String RULE = "team approve job";
+
+    @Autowired
+    AuthenticatedUser authenticatedUser;
+
+    @Autowired
+    GroupService groupService;
+
+    @Override
+    public boolean ok(Job job, RequestScope requestScope, Optional<ChangeSpec> optional) {
+        if (job.getApprovalTeam() == null)
+            return true;
+        else {
+            if (groupService.isMember(authenticatedUser.getEmail(requestScope.getUser()), job.getApprovalTeam()))
+                return true;
+            else
+                return false;
+        }
+    }
+}

--- a/api/src/main/java/org/azbuilder/api/rs/checks/job/TeamApproveJob.java
+++ b/api/src/main/java/org/azbuilder/api/rs/checks/job/TeamApproveJob.java
@@ -28,7 +28,7 @@ public class TeamApproveJob extends OperationCheck<Job> {
         if (job.getApprovalTeam() == null)
             return true;
         else {
-            return groupService.isMember(authenticatedUser.getEmail(requestScope.getUser()), job.getApprovalTeam())
+            return groupService.isMember(authenticatedUser.getEmail(requestScope.getUser()), job.getApprovalTeam());
         }
     }
 }

--- a/api/src/main/java/org/azbuilder/api/rs/checks/job/TeamApproveJob.java
+++ b/api/src/main/java/org/azbuilder/api/rs/checks/job/TeamApproveJob.java
@@ -28,10 +28,7 @@ public class TeamApproveJob extends OperationCheck<Job> {
         if (job.getApprovalTeam() == null)
             return true;
         else {
-            if (groupService.isMember(authenticatedUser.getEmail(requestScope.getUser()), job.getApprovalTeam()))
-                return true;
-            else
-                return false;
+            return groupService.isMember(authenticatedUser.getEmail(requestScope.getUser()), job.getApprovalTeam())
         }
     }
 }

--- a/api/src/main/java/org/azbuilder/api/rs/job/Job.java
+++ b/api/src/main/java/org/azbuilder/api/rs/job/Job.java
@@ -2,7 +2,6 @@ package org.azbuilder.api.rs.job;
 
 import com.yahoo.elide.annotation.CreatePermission;
 import com.yahoo.elide.annotation.Include;
-import com.yahoo.elide.annotation.ReadPermission;
 import com.yahoo.elide.annotation.UpdatePermission;
 import lombok.Getter;
 import lombok.Setter;

--- a/api/src/main/java/org/azbuilder/api/rs/job/Job.java
+++ b/api/src/main/java/org/azbuilder/api/rs/job/Job.java
@@ -1,6 +1,9 @@
 package org.azbuilder.api.rs.job;
 
+import com.yahoo.elide.annotation.CreatePermission;
 import com.yahoo.elide.annotation.Include;
+import com.yahoo.elide.annotation.ReadPermission;
+import com.yahoo.elide.annotation.UpdatePermission;
 import lombok.Getter;
 import lombok.Setter;
 import org.azbuilder.api.plugin.security.audit.GenericAuditFields;
@@ -21,6 +24,7 @@ public class Job extends GenericAuditFields {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
 
+    @UpdatePermission(expression = "team approve job OR user is a service")
     @Enumerated(EnumType.STRING)
     private JobStatus status = JobStatus.pending;
 
@@ -29,6 +33,11 @@ public class Job extends GenericAuditFields {
 
     @Column(name = "terraform_plan")
     private String terraformPlan;
+
+    @CreatePermission(expression = "user is a service")
+    @UpdatePermission(expression = "user is a service")
+    @Column(name = "approval_team")
+    private String approvalTeam;
 
     @Column(name = "tcl")
     private String tcl;

--- a/api/src/main/java/org/azbuilder/api/rs/job/JobStatus.java
+++ b/api/src/main/java/org/azbuilder/api/rs/job/JobStatus.java
@@ -2,6 +2,8 @@ package org.azbuilder.api.rs.job;
 
 public enum JobStatus {
     pending,
+    waitingApproval,
+    approved,
     queue,
     running,
     completed

--- a/api/src/main/resources/db/changelog/local/changelog-1.6.xml
+++ b/api/src/main/resources/db/changelog/local/changelog-1.6.xml
@@ -14,6 +14,9 @@
             <column name="created_by" type="varchar2(128)"/>
             <column name="updated_by" type="varchar2(128)"/>
         </addColumn>
+        <addColumn tableName="job" >
+            <column name="approval_team" type="varchar2(64)"/>
+        </addColumn>
         <createTable tableName="schedule">
             <column name="id" type="varchar(36)">
                 <constraints primaryKey="true"/>

--- a/api/src/test/java/org/azbuilder/api/JobTests.java
+++ b/api/src/test/java/org/azbuilder/api/JobTests.java
@@ -33,6 +33,7 @@ class JobTests extends ServerApplicationTests{
                                         type( "job"),
                                         id("1"),
                                         attributes(
+                                                attr("approvalTeam", null),
                                                 attr("createdBy", null),
                                                 attr("createdDate", null),
                                                 attr("output", "sampleOutput"),


### PR DESCRIPTION
Add support to stop a job for an approval using a new terrakube configuration language definition.

Example:
```yaml
flow:
- type: "terraformPlan"
  step: 100
  commands:
    - runtime: "GROOVY"
      priority: 100
      after: true
      script: |
        import Infracost

        String credentials = "version: \"0.1\"\n" +
                "api_key: $INFRACOST_KEY \n" +
                "pricing_api_endpoint: https://pricing.api.infracost.io"

        new Infracost().loadTool(
           "$workingDirectory",
           "$bashToolsDirectory", 
           "0.9.11",
           credentials)
        "Infracost Download Completed..."
    - runtime: "BASH"
      priority: 200
      after: true
      script: |
        terraform show -json terraformLibrary.tfPlan > plan.json 
        infracost breakdown --path plan.json
- type: "approval"
  team: "AZB_ADMIN"
  step: 200
- type: "terraformApply"
  step: 300
```

To continue the job execution the team will have to update the status to "approved"

Example:

```
PATCH: {{server}}/api/v1/organization/{{organizationId}}/job/{{jobId}}
{
  "data": {
    "type": "job",
    "id": "{{jobId}}",
    "attributes": {
      "status": "approved"
    }
  }
}
```