### PR TITLE
Fix cluster configuration quartz

### DIFF
--- a/api/src/main/java/org/azbuilder/api/plugin/scheduler/configuration/QuartzAutoConfiguration.java
+++ b/api/src/main/java/org/azbuilder/api/plugin/scheduler/configuration/QuartzAutoConfiguration.java
@@ -44,6 +44,8 @@ public class QuartzAutoConfiguration {
         schedulerFactoryBean.setDataSource(quartzDataSource);
         Properties properties = new Properties();
         properties.put("org.quartz.jobStore.class","org.quartz.impl.jdbcjobstore.JobStoreTX");
+        properties.put("org.quartz.jobStore.isClustered","true");
+        properties.put("org.quartz.scheduler.instanceId","AUTO");
         switch(dataSourceConfigurationProperties.getType()){
             case SQL_AZURE:
                 properties.put("org.quartz.jobStore.driverDelegateClass","org.quartz.impl.jdbcjobstore.MSSQLDelegate");

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -83,5 +83,3 @@ org.terrakube.hostname=${TerrakubeHostname}
 ##############
 spring.quartz.job-store-type=jdbc
 spring.quartz.jdbc.initialize-schema=never
-spring.quartz.properties.org.quartz.jobStore.isClustered=true
-spring.quartz.properties.org.quartz.scheduler.instanceId=AUTO


### PR DESCRIPTION
This should fix the cluster configuration issue and Fixes #97 
````
  Scheduler class: 'org.quartz.core.QuartzScheduler' - running locally.
  NOT STARTED.
  Currently in standby mode.
  Number of jobs executed: 0
  Using thread pool 'org.quartz.simpl.SimpleThreadPool' - with 10 threads.
  Using job-store 'org.springframework.scheduling.quartz.LocalDataSourceJobStore' - which supports persistence. and is clustered.
````