### PR TITLE
Allow Azure AD application to be part of an organization group

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -17,7 +17,7 @@
         <java.version>11</java.version>
         <elide.version>6.0.4</elide.version>
         <liquibase-core.version>4.8.0</liquibase-core.version>
-        <azure.version>3.12.0</azure.version>
+        <azure.version>3.13.1</azure.version>
         <mssql-jdbc.version>9.2.1.jre11</mssql-jdbc.version>
         <msal4j.version>1.10.1</msal4j.version>
         <lombok.version>1.18.20</lombok.version>

--- a/api/src/main/java/org/azbuilder/api/plugin/security/groups/GroupService.java
+++ b/api/src/main/java/org/azbuilder/api/plugin/security/groups/GroupService.java
@@ -4,4 +4,5 @@ public interface GroupService {
 
     boolean isMember(String user, String group);
 
+    boolean isServiceMember(String application, String group);
 }

--- a/api/src/main/java/org/azbuilder/api/plugin/security/groups/local/LocalGroupServiceImpl.java
+++ b/api/src/main/java/org/azbuilder/api/plugin/security/groups/local/LocalGroupServiceImpl.java
@@ -11,4 +11,7 @@ public class LocalGroupServiceImpl implements GroupService {
     public boolean isMember(String user, String group) {
         return true;
     }
+
+    @Override
+    public boolean isServiceMember(String application, String group) { return true; }
 }

--- a/api/src/main/java/org/azbuilder/api/plugin/security/user/AuthenticatedUser.java
+++ b/api/src/main/java/org/azbuilder/api/plugin/security/user/AuthenticatedUser.java
@@ -6,5 +6,9 @@ public interface AuthenticatedUser {
 
     String getEmail(User user);
 
+    String getApplication(User user);
+
     public boolean isServiceAccount(User user);
+
+    public boolean isSuperUser(User user);
 }

--- a/api/src/main/java/org/azbuilder/api/plugin/security/user/azure/AzureAuthenticatedUserImpl.java
+++ b/api/src/main/java/org/azbuilder/api/plugin/security/user/azure/AzureAuthenticatedUserImpl.java
@@ -3,7 +3,10 @@ package org.azbuilder.api.plugin.security.user.azure;
 import com.azure.spring.aad.AADOAuth2AuthenticatedPrincipal;
 import com.yahoo.elide.core.security.User;
 import lombok.extern.slf4j.Slf4j;
+import org.azbuilder.api.plugin.security.groups.GroupService;
 import org.azbuilder.api.plugin.security.user.AuthenticatedUser;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
@@ -11,6 +14,12 @@ import org.springframework.stereotype.Service;
 @Service
 @ConditionalOnProperty(prefix = "org.azbuilder.api.users", name = "type", havingValue = "AZURE")
 public class AzureAuthenticatedUserImpl implements AuthenticatedUser {
+
+    @Value("${org.azbuilder.owner}")
+    private String instanceOwner;
+
+    @Autowired
+    GroupService groupService;
 
     private AADOAuth2AuthenticatedPrincipal getAzureAdPrincipal(User user) {
         org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthentication bearerTokenAuthenticationToken = (org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthentication) user.getPrincipal();
@@ -22,10 +31,47 @@ public class AzureAuthenticatedUserImpl implements AuthenticatedUser {
         return (String) getAzureAdPrincipal(user).getAttributes().get("unique_name");
     }
 
-    // Azure AD Token Documentation https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens
+    @Override
+    public String getApplication(User user) {
+        log.info("oid {}",getAzureAdPrincipal(user).getAttributes().get("oid"));
+        return (String) getAzureAdPrincipal(user).getAttributes().get("oid");
+    }
+
+    /**
+     * Reference Azure AD Token Documentation https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens
+     * appidacr = 0 (public client authentication)
+     * appidacr = 1 (client credentials authentication) will be considered as service account in Terrakube
+     * appidacr = 2 (client certificate authentication)
+     *
+     * @param user
+     * @return
+     */
     @Override
     public boolean isServiceAccount(User user) {
         AADOAuth2AuthenticatedPrincipal aadoAuth2AuthenticatedPrincipal = getAzureAdPrincipal(user);
         return ((String) aadoAuth2AuthenticatedPrincipal.getAttributes().get("appidacr")).equals("1");
+    }
+
+    /**
+     * Review is the authenticated user belongs to the Terrakube instance admin group.
+     * @param user
+     * @return
+     */
+    @Override
+    public boolean isSuperUser(User user){
+        boolean isServiceAccount=isServiceAccount(user);
+        boolean isSuperUser;
+        String applicationName="";
+        String userName="";
+        if (isServiceAccount){
+            applicationName = getApplication(user);
+            isSuperUser = groupService.isServiceMember(applicationName, instanceOwner);
+        }else{
+            userName = getEmail(user);
+            isSuperUser = groupService.isMember(userName, instanceOwner);
+        }
+
+        log.info("{} is super user", isServiceAccount ? applicationName : userName);
+        return isSuperUser;
     }
 }

--- a/api/src/main/java/org/azbuilder/api/plugin/security/user/local/LocalAuthenticatedUserImpl.java
+++ b/api/src/main/java/org/azbuilder/api/plugin/security/user/local/LocalAuthenticatedUserImpl.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 public class LocalAuthenticatedUserImpl implements AuthenticatedUser {
 
     private static final String LOCAL_USER="local@user.com";
+    private static final String LOCAL_APPLICATION="0";
 
     @Override
     public String getEmail(User user) {
@@ -17,7 +18,15 @@ public class LocalAuthenticatedUserImpl implements AuthenticatedUser {
     }
 
     @Override
+    public String getApplication(User user) { return LOCAL_APPLICATION; }
+
+    @Override
     public boolean isServiceAccount(User user) {
+        return true;
+    }
+
+    @Override
+    public boolean isSuperUser(User user) {
         return true;
     }
 }

--- a/api/src/main/java/org/azbuilder/api/rs/Organization.java
+++ b/api/src/main/java/org/azbuilder/api/rs/Organization.java
@@ -16,7 +16,7 @@ import javax.persistence.*;
 import java.util.List;
 import java.util.UUID;
 
-@ReadPermission(expression = "user belongs organization OR user is a service")
+@ReadPermission(expression = "user belongs organization")
 @CreatePermission(expression = "user is a superuser")
 @UpdatePermission(expression = "user is a superuser ")
 @DeletePermission(expression = "user is a superuser")

--- a/api/src/main/java/org/azbuilder/api/rs/Organization.java
+++ b/api/src/main/java/org/azbuilder/api/rs/Organization.java
@@ -56,9 +56,11 @@ public class Organization {
     @OneToMany(mappedBy = "organization")
     private List<Team> team;
 
+    @UpdatePermission(expression = "user belongs organization")
     @OneToMany(mappedBy = "organization")
     private List<Vcs> vcs;
 
+    @UpdatePermission(expression = "user belongs organization")
     @OneToMany(mappedBy = "organization")
     private List<Template> template;
 }

--- a/api/src/main/java/org/azbuilder/api/rs/checks/job/TeamApproveJob.java
+++ b/api/src/main/java/org/azbuilder/api/rs/checks/job/TeamApproveJob.java
@@ -28,7 +28,10 @@ public class TeamApproveJob extends OperationCheck<Job> {
         if (job.getApprovalTeam() == null || job.getApprovalTeam().isEmpty())
             return true;
         else {
-            return groupService.isMember(authenticatedUser.getEmail(requestScope.getUser()), job.getApprovalTeam());
+            if (!authenticatedUser.isServiceAccount(requestScope.getUser()))
+                return groupService.isMember(authenticatedUser.getEmail(requestScope.getUser()), job.getApprovalTeam());
+            else
+                return true;
         }
     }
 }

--- a/api/src/main/java/org/azbuilder/api/rs/checks/membership/MembershipService.java
+++ b/api/src/main/java/org/azbuilder/api/rs/checks/membership/MembershipService.java
@@ -1,0 +1,42 @@
+package org.azbuilder.api.rs.checks.membership;
+
+import com.yahoo.elide.core.security.User;
+import lombok.extern.slf4j.Slf4j;
+import org.azbuilder.api.plugin.security.groups.GroupService;
+import org.azbuilder.api.plugin.security.user.AuthenticatedUser;
+import org.azbuilder.api.rs.team.Team;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@Slf4j
+public class MembershipService {
+
+    @Autowired
+    AuthenticatedUser authenticatedUser;
+
+    @Autowired
+    GroupService groupService;
+
+    public boolean checkMembership(User user, List<Team> teamList) {
+        for (Team team : teamList) {
+            if (authenticatedUser.isServiceAccount(user)) {
+                String applicationName = authenticatedUser.getApplication(user);
+                if (groupService.isServiceMember(applicationName, team.getName())) {
+                    log.info("application {} is member of {}", applicationName, team.getName());
+                    return true;
+                }
+            } else {
+                String userName = authenticatedUser.getEmail(user);
+                if (groupService.isMember(userName, team.getName()))
+                    log.info("user {} is member of {}", userName, team.getName());
+                return true;
+            }
+        }
+        return false;
+    }
+
+}

--- a/api/src/main/java/org/azbuilder/api/rs/checks/module/TeamManageModule.java
+++ b/api/src/main/java/org/azbuilder/api/rs/checks/module/TeamManageModule.java
@@ -29,10 +29,17 @@ public class TeamManageModule extends OperationCheck<Module> {
     @Override
     public boolean ok(Module module, RequestScope requestScope, Optional<ChangeSpec> optional) {
         log.info("team manage module {}", module.getId());
+        boolean isServiceAccount = authenticatedUser.isServiceAccount(requestScope.getUser());
         List<Team> teamList = module.getOrganization().getTeam();
         for (Team team : teamList) {
-            if(groupService.isMember(authenticatedUser.getEmail(requestScope.getUser()), team.getName()) && team.isManageModule())
-                return true;
+            if (isServiceAccount){
+                if (groupService.isServiceMember(authenticatedUser.getApplication(requestScope.getUser()), team.getName()) && team.isManageModule() ){
+                    return true;
+                }
+            } else {
+                if (groupService.isMember(authenticatedUser.getEmail(requestScope.getUser()), team.getName()) && team.isManageModule())
+                    return true;
+            }
         }
         return false;
     }

--- a/api/src/main/java/org/azbuilder/api/rs/checks/module/TeamViewModule.java
+++ b/api/src/main/java/org/azbuilder/api/rs/checks/module/TeamViewModule.java
@@ -29,11 +29,22 @@ public class TeamViewModule extends OperationCheck<Module> {
     @Override
     public boolean ok(Module module, RequestScope requestScope, Optional<ChangeSpec> optional) {
         log.info("team view module {}", module.getId());
+        boolean isServiceAccount = authenticatedUser.isServiceAccount(requestScope.getUser());
         List<Team> teamList = module.getOrganization().getTeam();
-        for (Team team : teamList) {
-            if (groupService.isMember(authenticatedUser.getEmail(requestScope.getUser()), team.getName()))
-                return true;
+        if (authenticatedUser.isSuperUser(requestScope.getUser())) {
+            return true;
+        } else {
+            for (Team team : teamList) {
+                if (authenticatedUser.isServiceAccount(requestScope.getUser())){
+                    if (groupService.isServiceMember(authenticatedUser.getApplication(requestScope.getUser()), team.getName()) ){
+                        return true;
+                    }
+                } else {
+                    if (groupService.isMember(authenticatedUser.getEmail(requestScope.getUser()), team.getName()))
+                        return true;
+                }
+            }
+            return false;
         }
-        return false;
     }
 }

--- a/api/src/main/java/org/azbuilder/api/rs/checks/module/TeamViewModule.java
+++ b/api/src/main/java/org/azbuilder/api/rs/checks/module/TeamViewModule.java
@@ -5,8 +5,8 @@ import com.yahoo.elide.core.security.ChangeSpec;
 import com.yahoo.elide.core.security.RequestScope;
 import com.yahoo.elide.core.security.checks.OperationCheck;
 import lombok.extern.slf4j.Slf4j;
-import org.azbuilder.api.plugin.security.groups.GroupService;
 import org.azbuilder.api.plugin.security.user.AuthenticatedUser;
+import org.azbuilder.api.rs.checks.membership.MembershipService;
 import org.azbuilder.api.rs.module.Module;
 import org.azbuilder.api.rs.team.Team;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,27 +24,12 @@ public class TeamViewModule extends OperationCheck<Module> {
     AuthenticatedUser authenticatedUser;
 
     @Autowired
-    GroupService groupService;
+    MembershipService membershipService;
 
     @Override
     public boolean ok(Module module, RequestScope requestScope, Optional<ChangeSpec> optional) {
         log.info("team view module {}", module.getId());
-        boolean isServiceAccount = authenticatedUser.isServiceAccount(requestScope.getUser());
         List<Team> teamList = module.getOrganization().getTeam();
-        if (authenticatedUser.isSuperUser(requestScope.getUser())) {
-            return true;
-        } else {
-            for (Team team : teamList) {
-                if (authenticatedUser.isServiceAccount(requestScope.getUser())){
-                    if (groupService.isServiceMember(authenticatedUser.getApplication(requestScope.getUser()), team.getName()) ){
-                        return true;
-                    }
-                } else {
-                    if (groupService.isMember(authenticatedUser.getEmail(requestScope.getUser()), team.getName()))
-                        return true;
-                }
-            }
-            return false;
-        }
+        return authenticatedUser.isSuperUser(requestScope.getUser()) ? true : membershipService.checkMembership(requestScope.getUser(), teamList);
     }
 }

--- a/api/src/main/java/org/azbuilder/api/rs/checks/organization/UserBelongsOrganization.java
+++ b/api/src/main/java/org/azbuilder/api/rs/checks/organization/UserBelongsOrganization.java
@@ -3,6 +3,7 @@ package org.azbuilder.api.rs.checks.organization;
 import com.yahoo.elide.annotation.SecurityCheck;
 import com.yahoo.elide.core.security.ChangeSpec;
 import com.yahoo.elide.core.security.RequestScope;
+import com.yahoo.elide.core.security.User;
 import com.yahoo.elide.core.security.checks.OperationCheck;
 import lombok.extern.slf4j.Slf4j;
 import org.azbuilder.api.plugin.security.groups.GroupService;
@@ -10,7 +11,6 @@ import org.azbuilder.api.plugin.security.user.AuthenticatedUser;
 import org.azbuilder.api.rs.Organization;
 import org.azbuilder.api.rs.team.Team;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 
 import java.util.List;
 import java.util.Optional;
@@ -21,9 +21,6 @@ public class UserBelongsOrganization extends OperationCheck<Organization> {
 
     public static final String RULE = "user belongs organization";
 
-    @Value("${org.azbuilder.owner}")
-    private String instanceOwner;
-
     @Autowired
     AuthenticatedUser authenticatedUser;
 
@@ -32,20 +29,44 @@ public class UserBelongsOrganization extends OperationCheck<Organization> {
 
     @Override
     public boolean ok(Organization organization, RequestScope requestScope, Optional<ChangeSpec> optional) {
-        log.info("user view organization {}",authenticatedUser.getEmail(requestScope.getUser()));
-        if (groupService.isMember(authenticatedUser.getEmail(requestScope.getUser()), instanceOwner)) {
-            log.info("{} is super user", authenticatedUser.getEmail(requestScope.getUser()));
+        if(authenticatedUser.isSuperUser(requestScope.getUser())){
             return true;
+        }else{
+            return isMemberOrganization(requestScope.getUser(), organization);
         }
-        else {
-            log.info("{} is not super user", authenticatedUser.getEmail(requestScope.getUser()));
-            List<Team> teamList = organization.getTeam();
-            for (Team team : teamList) {
-                log.info("isMember {} {}", team.getName(), groupService.isMember(authenticatedUser.getEmail(requestScope.getUser()), team.getName()));
-                if(groupService.isMember(authenticatedUser.getEmail(requestScope.getUser()), team.getName()))
+    }
+
+    /**
+     * Review is the authenticated user belongs to the organization by searching the membership in each organization team
+     * @param user
+     * @param organization
+     * @return
+     */
+    private boolean isMemberOrganization(User user, Organization organization){
+        boolean isServiceAccount=authenticatedUser.isServiceAccount(user);
+        String applicationName="";
+        String userName="";
+        if (isServiceAccount){
+            applicationName = authenticatedUser.getApplication(user);
+        }else{
+            userName = authenticatedUser.getEmail(user);
+        }
+
+        List<Team> teamList = organization.getTeam();
+        for (Team team : teamList) {
+            if (isServiceAccount) {
+                log.info("isServiceMember {} {}", team.getName(), groupService.isServiceMember(applicationName, team.getName()));
+                if (groupService.isServiceMember(applicationName, team.getName())) {
+                    return true;
+                }
+            } else {
+                log.info("isMember {} {}", team.getName(), groupService.isMember(userName, team.getName()));
+                if (groupService.isMember(userName, team.getName()))
                     return true;
             }
         }
         return false;
     }
+
+
 }

--- a/api/src/main/java/org/azbuilder/api/rs/checks/provider/TeamManageProvider.java
+++ b/api/src/main/java/org/azbuilder/api/rs/checks/provider/TeamManageProvider.java
@@ -29,10 +29,17 @@ public class TeamManageProvider extends OperationCheck<Provider> {
     @Override
     public boolean ok(Provider provider, RequestScope requestScope, Optional<ChangeSpec> optional) {
         log.info("team manage provider {}", provider.getId());
+        boolean isServiceAccount = authenticatedUser.isServiceAccount(requestScope.getUser());
         List<Team> teamList = provider.getOrganization().getTeam();
         for (Team team : teamList) {
-            if(groupService.isMember(authenticatedUser.getEmail(requestScope.getUser()), team.getName()) && team.isManageProvider())
-                return true;
+            if (isServiceAccount){
+                if (groupService.isServiceMember(authenticatedUser.getApplication(requestScope.getUser()), team.getName()) && team.isManageProvider() ){
+                    return true;
+                }
+            } else {
+                if (groupService.isMember(authenticatedUser.getEmail(requestScope.getUser()), team.getName()) && team.isManageProvider())
+                    return true;
+            }
         }
         return false;
     }

--- a/api/src/main/java/org/azbuilder/api/rs/checks/provider/TeamViewProvider.java
+++ b/api/src/main/java/org/azbuilder/api/rs/checks/provider/TeamViewProvider.java
@@ -5,8 +5,8 @@ import com.yahoo.elide.core.security.ChangeSpec;
 import com.yahoo.elide.core.security.RequestScope;
 import com.yahoo.elide.core.security.checks.OperationCheck;
 import lombok.extern.slf4j.Slf4j;
-import org.azbuilder.api.plugin.security.groups.GroupService;
 import org.azbuilder.api.plugin.security.user.AuthenticatedUser;
+import org.azbuilder.api.rs.checks.membership.MembershipService;
 import org.azbuilder.api.rs.provider.Provider;
 import org.azbuilder.api.rs.team.Team;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,27 +24,12 @@ public class TeamViewProvider extends OperationCheck<Provider> {
     AuthenticatedUser authenticatedUser;
 
     @Autowired
-    GroupService groupService;
+    MembershipService membershipService;
 
     @Override
     public boolean ok(Provider provider, RequestScope requestScope, Optional<ChangeSpec> optional) {
         log.info("team view provider {}", provider.getId());
-        boolean isServiceAccount = authenticatedUser.isServiceAccount(requestScope.getUser());
         List<Team> teamList = provider.getOrganization().getTeam();
-        if (authenticatedUser.isSuperUser(requestScope.getUser())) {
-            return true;
-        } else {
-            for (Team team : teamList) {
-                if (isServiceAccount){
-                    if (groupService.isServiceMember(authenticatedUser.getApplication(requestScope.getUser()), team.getName()) ){
-                        return true;
-                    }
-                } else {
-                    if (groupService.isMember(authenticatedUser.getEmail(requestScope.getUser()), team.getName()))
-                        return true;
-                }
-            }
-            return false;
-        }
+        return authenticatedUser.isSuperUser(requestScope.getUser()) ? true : membershipService.checkMembership(requestScope.getUser(), teamList);
     }
 }

--- a/api/src/main/java/org/azbuilder/api/rs/checks/provider/TeamViewProvider.java
+++ b/api/src/main/java/org/azbuilder/api/rs/checks/provider/TeamViewProvider.java
@@ -29,11 +29,22 @@ public class TeamViewProvider extends OperationCheck<Provider> {
     @Override
     public boolean ok(Provider provider, RequestScope requestScope, Optional<ChangeSpec> optional) {
         log.info("team view provider {}", provider.getId());
+        boolean isServiceAccount = authenticatedUser.isServiceAccount(requestScope.getUser());
         List<Team> teamList = provider.getOrganization().getTeam();
-        for (Team team : teamList) {
-            if(groupService.isMember(authenticatedUser.getEmail(requestScope.getUser()), team.getName()))
-                return true;
+        if (authenticatedUser.isSuperUser(requestScope.getUser())) {
+            return true;
+        } else {
+            for (Team team : teamList) {
+                if (isServiceAccount){
+                    if (groupService.isServiceMember(authenticatedUser.getApplication(requestScope.getUser()), team.getName()) ){
+                        return true;
+                    }
+                } else {
+                    if (groupService.isMember(authenticatedUser.getEmail(requestScope.getUser()), team.getName()))
+                        return true;
+                }
+            }
+            return false;
         }
-        return false;
     }
 }

--- a/api/src/main/java/org/azbuilder/api/rs/checks/template/TeamManageTemplate.java
+++ b/api/src/main/java/org/azbuilder/api/rs/checks/template/TeamManageTemplate.java
@@ -30,10 +30,17 @@ public class TeamManageTemplate extends OperationCheck<Template> {
     @Override
     public boolean ok(Template template, RequestScope requestScope, Optional<ChangeSpec> optional) {
         log.info("team manage template {}", template.getId());
+        boolean isServiceAccount = authenticatedUser.isServiceAccount(requestScope.getUser());
         List<Team> teamList = template.getOrganization().getTeam();
         for (Team team : teamList) {
-            if(groupService.isMember(authenticatedUser.getEmail(requestScope.getUser()), team.getName()) && team.isManageTemplate())
-                return true;
+            if (isServiceAccount){
+                if (groupService.isServiceMember(authenticatedUser.getApplication(requestScope.getUser()), team.getName()) && team.isManageTemplate() ){
+                    return true;
+                }
+            } else {
+                if (groupService.isMember(authenticatedUser.getEmail(requestScope.getUser()), team.getName()) && team.isManageTemplate())
+                    return true;
+            }
         }
         return false;
     }

--- a/api/src/main/java/org/azbuilder/api/rs/checks/template/TeamViewTemplate.java
+++ b/api/src/main/java/org/azbuilder/api/rs/checks/template/TeamViewTemplate.java
@@ -5,8 +5,8 @@ import com.yahoo.elide.core.security.ChangeSpec;
 import com.yahoo.elide.core.security.RequestScope;
 import com.yahoo.elide.core.security.checks.OperationCheck;
 import lombok.extern.slf4j.Slf4j;
-import org.azbuilder.api.plugin.security.groups.GroupService;
 import org.azbuilder.api.plugin.security.user.AuthenticatedUser;
+import org.azbuilder.api.rs.checks.membership.MembershipService;
 import org.azbuilder.api.rs.team.Team;
 import org.azbuilder.api.rs.template.Template;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,27 +23,12 @@ public class TeamViewTemplate extends OperationCheck<Template> {
     AuthenticatedUser authenticatedUser;
 
     @Autowired
-    GroupService groupService;
+    MembershipService membershipService;
 
     @Override
     public boolean ok(Template template, RequestScope requestScope, Optional<ChangeSpec> optional) {
         log.info("team view template {}", template.getId());
-        boolean isServiceAccount = authenticatedUser.isServiceAccount(requestScope.getUser());
         List<Team> teamList = template.getOrganization().getTeam();
-        if (authenticatedUser.isSuperUser(requestScope.getUser())) {
-            return true;
-        } else {
-            for (Team team : teamList) {
-                if (isServiceAccount){
-                    if (groupService.isServiceMember(authenticatedUser.getApplication(requestScope.getUser()), team.getName()) ){
-                        return true;
-                    }
-                } else {
-                    if (groupService.isMember(authenticatedUser.getEmail(requestScope.getUser()), team.getName()))
-                        return true;
-                }
-            }
-            return false;
-        }
+        return authenticatedUser.isSuperUser(requestScope.getUser()) ? true : membershipService.checkMembership(requestScope.getUser(), teamList);
     }
 }

--- a/api/src/main/java/org/azbuilder/api/rs/checks/template/TeamViewTemplate.java
+++ b/api/src/main/java/org/azbuilder/api/rs/checks/template/TeamViewTemplate.java
@@ -28,11 +28,22 @@ public class TeamViewTemplate extends OperationCheck<Template> {
     @Override
     public boolean ok(Template template, RequestScope requestScope, Optional<ChangeSpec> optional) {
         log.info("team view template {}", template.getId());
+        boolean isServiceAccount = authenticatedUser.isServiceAccount(requestScope.getUser());
         List<Team> teamList = template.getOrganization().getTeam();
-        for (Team team : teamList) {
-            if(groupService.isMember(authenticatedUser.getEmail(requestScope.getUser()), team.getName()))
-                return true;
+        if (authenticatedUser.isSuperUser(requestScope.getUser())) {
+            return true;
+        } else {
+            for (Team team : teamList) {
+                if (isServiceAccount){
+                    if (groupService.isServiceMember(authenticatedUser.getApplication(requestScope.getUser()), team.getName()) ){
+                        return true;
+                    }
+                } else {
+                    if (groupService.isMember(authenticatedUser.getEmail(requestScope.getUser()), team.getName()))
+                        return true;
+                }
+            }
+            return false;
         }
-        return false;
     }
 }

--- a/api/src/main/java/org/azbuilder/api/rs/checks/user/IsServiceUser.java
+++ b/api/src/main/java/org/azbuilder/api/rs/checks/user/IsServiceUser.java
@@ -7,6 +7,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.azbuilder.api.plugin.security.user.AuthenticatedUser;
 import org.springframework.beans.factory.annotation.Autowired;
 
+
+@Deprecated
 @Slf4j
 @SecurityCheck(IsServiceUser.RULE)
 public class IsServiceUser extends UserCheck {

--- a/api/src/main/java/org/azbuilder/api/rs/checks/user/isSuperService.java
+++ b/api/src/main/java/org/azbuilder/api/rs/checks/user/isSuperService.java
@@ -10,10 +10,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 
 @Slf4j
-@SecurityCheck(IsSuperUser.RULE)
-public class IsSuperUser extends UserCheck {
+@SecurityCheck(isSuperService.RULE)
+public class isSuperService extends UserCheck {
 
-    public static final String RULE = "user is a superuser";
+    public static final String RULE = "user is a super service";
 
     @Autowired
     AuthenticatedUser authenticatedUser;
@@ -26,11 +26,10 @@ public class IsSuperUser extends UserCheck {
 
     @Override
     public boolean ok(User user) {
-        if (authenticatedUser.isServiceAccount(user)){
+        if (authenticatedUser.isServiceAccount(user)) {
             return groupService.isServiceMember(authenticatedUser.getApplication(user), instanceOwner);
-        }else{
-            return groupService.isMember(authenticatedUser.getEmail(user), instanceOwner);
+        } else {
+            return false;
         }
     }
 }
-

--- a/api/src/main/java/org/azbuilder/api/rs/checks/variable/UserReadSecret.java
+++ b/api/src/main/java/org/azbuilder/api/rs/checks/variable/UserReadSecret.java
@@ -12,10 +12,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.util.Optional;
 
 @Slf4j
-@SecurityCheck(ServiceReadSecret.RULE)
-public class ServiceReadSecret extends OperationCheck<Variable> {
+@SecurityCheck(UserReadSecret.RULE)
+public class UserReadSecret extends OperationCheck<Variable> {
 
-    public static final String RULE = "service read secret";
+    public static final String RULE = "user read secret";
 
     @Autowired
     AuthenticatedUser authenticatedUser;
@@ -24,7 +24,7 @@ public class ServiceReadSecret extends OperationCheck<Variable> {
     public boolean ok(Variable variable, RequestScope requestScope, Optional<ChangeSpec> optional) {
         log.info("user view variable {}", variable.getId());
         if(variable.isSensitive()) {
-            return authenticatedUser.isServiceAccount(requestScope.getUser());
+            return false;
         }
         else
             return true;

--- a/api/src/main/java/org/azbuilder/api/rs/checks/vcs/ReadVcsSecret.java
+++ b/api/src/main/java/org/azbuilder/api/rs/checks/vcs/ReadVcsSecret.java
@@ -12,8 +12,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.util.Optional;
 
 @Slf4j
-@SecurityCheck(ServiceReadVcsSecret.RULE)
-public class ServiceReadVcsSecret extends OperationCheck<Vcs> {
+@SecurityCheck(ReadVcsSecret.RULE)
+public class ReadVcsSecret extends OperationCheck<Vcs> {
     public static final String RULE = "read vcs secret";
 
     @Autowired

--- a/api/src/main/java/org/azbuilder/api/rs/checks/vcs/ServiceReadVcsSecret.java
+++ b/api/src/main/java/org/azbuilder/api/rs/checks/vcs/ServiceReadVcsSecret.java
@@ -11,11 +11,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Optional;
 
-@Deprecated
 @Slf4j
 @SecurityCheck(ServiceReadVcsSecret.RULE)
 public class ServiceReadVcsSecret extends OperationCheck<Vcs> {
-    public static final String RULE = "service read vcs secret";
+    public static final String RULE = "read vcs secret";
 
     @Autowired
     AuthenticatedUser authenticatedUser;
@@ -23,6 +22,6 @@ public class ServiceReadVcsSecret extends OperationCheck<Vcs> {
     @Override
     public boolean ok(Vcs vcs, RequestScope requestScope, Optional<ChangeSpec> optional) {
         log.info("user view vcs {}", vcs.getId());
-        return authenticatedUser.isServiceAccount(requestScope.getUser());
+        return false;
     }
 }

--- a/api/src/main/java/org/azbuilder/api/rs/checks/vcs/ServiceReadVcsSecret.java
+++ b/api/src/main/java/org/azbuilder/api/rs/checks/vcs/ServiceReadVcsSecret.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Optional;
 
+@Deprecated
 @Slf4j
 @SecurityCheck(ServiceReadVcsSecret.RULE)
 public class ServiceReadVcsSecret extends OperationCheck<Vcs> {

--- a/api/src/main/java/org/azbuilder/api/rs/checks/vcs/TeamManageVcs.java
+++ b/api/src/main/java/org/azbuilder/api/rs/checks/vcs/TeamManageVcs.java
@@ -28,10 +28,17 @@ public class TeamManageVcs extends OperationCheck<Vcs> {
     @Override
     public boolean ok(Vcs vcs, RequestScope requestScope, Optional<ChangeSpec> optional) {
         log.info("team manage vcs {}", vcs.getId());
+        boolean isServiceAccount = authenticatedUser.isServiceAccount(requestScope.getUser());
         List<Team> teamList = vcs.getOrganization().getTeam();
         for (Team team : teamList) {
-            if(groupService.isMember(authenticatedUser.getEmail(requestScope.getUser()), team.getName()) && team.isManageVcs())
-                return true;
+            if (isServiceAccount){
+                if (groupService.isServiceMember(authenticatedUser.getApplication(requestScope.getUser()), team.getName()) && team.isManageVcs() ){
+                    return true;
+                }
+            } else {
+                if (groupService.isMember(authenticatedUser.getEmail(requestScope.getUser()), team.getName()) && team.isManageVcs())
+                    return true;
+            }
         }
         return false;
     }

--- a/api/src/main/java/org/azbuilder/api/rs/checks/vcs/TeamViewVcs.java
+++ b/api/src/main/java/org/azbuilder/api/rs/checks/vcs/TeamViewVcs.java
@@ -28,11 +28,22 @@ public class TeamViewVcs extends OperationCheck<Vcs> {
     @Override
     public boolean ok(Vcs vcs, RequestScope requestScope, Optional<ChangeSpec> optional) {
         log.info("team view vcs {}", vcs.getId());
+        boolean isServiceAccount = authenticatedUser.isServiceAccount(requestScope.getUser());
         List<Team> teamList = vcs.getOrganization().getTeam();
-        for (Team team : teamList) {
-            if(groupService.isMember(authenticatedUser.getEmail(requestScope.getUser()), team.getName()))
-                return true;
+        if (authenticatedUser.isSuperUser(requestScope.getUser())) {
+            return true;
+        } else {
+            for (Team team : teamList) {
+                if (isServiceAccount){
+                    if (groupService.isServiceMember(authenticatedUser.getApplication(requestScope.getUser()), team.getName()) ){
+                        return true;
+                    }
+                } else {
+                    if (groupService.isMember(authenticatedUser.getEmail(requestScope.getUser()), team.getName()))
+                        return true;
+                }
+            }
+            return false;
         }
-        return false;
     }
 }

--- a/api/src/main/java/org/azbuilder/api/rs/checks/workspace/TeamManageWorkspace.java
+++ b/api/src/main/java/org/azbuilder/api/rs/checks/workspace/TeamManageWorkspace.java
@@ -29,10 +29,17 @@ public class TeamManageWorkspace extends OperationCheck<Workspace> {
     @Override
     public boolean ok(Workspace workspace, RequestScope requestScope, Optional<ChangeSpec> optional) {
         log.info("team manage workspace {}", workspace.getId());
+        boolean isServiceAccount = authenticatedUser.isServiceAccount(requestScope.getUser());
         List<Team> teamList = workspace.getOrganization().getTeam();
         for (Team team : teamList) {
-             if(groupService.isMember(authenticatedUser.getEmail(requestScope.getUser()), team.getName()) && team.isManageWorkspace())
-                return true;
+            if (isServiceAccount){
+                if (groupService.isServiceMember(authenticatedUser.getApplication(requestScope.getUser()), team.getName()) && team.isManageWorkspace() ){
+                    return true;
+                }
+            } else {
+                if (groupService.isMember(authenticatedUser.getEmail(requestScope.getUser()), team.getName()) && team.isManageWorkspace())
+                    return true;
+            }
         }
         return false;
     }

--- a/api/src/main/java/org/azbuilder/api/rs/checks/workspace/TeamViewWorkspace.java
+++ b/api/src/main/java/org/azbuilder/api/rs/checks/workspace/TeamViewWorkspace.java
@@ -3,6 +3,7 @@ package org.azbuilder.api.rs.checks.workspace;
 import com.yahoo.elide.annotation.SecurityCheck;
 import com.yahoo.elide.core.security.ChangeSpec;
 import com.yahoo.elide.core.security.RequestScope;
+import com.yahoo.elide.core.security.User;
 import com.yahoo.elide.core.security.checks.OperationCheck;
 import lombok.extern.slf4j.Slf4j;
 import org.azbuilder.api.plugin.security.groups.GroupService;
@@ -33,16 +34,22 @@ public class TeamViewWorkspace extends OperationCheck<Workspace> {
     @Override
     public boolean ok(Workspace workspace, RequestScope requestScope, Optional<ChangeSpec> optional) {
         log.info("team view workspace {}", workspace.getId());
-        if (groupService.isMember(authenticatedUser.getEmail(requestScope.getUser()), instanceOwner)) {
-            log.info("{} is super user", authenticatedUser.getEmail(requestScope.getUser()));
+        if (authenticatedUser.isSuperUser(requestScope.getUser())) {
             return true;
         } else {
             List<Team> teamList = workspace.getOrganization().getTeam();
             for (Team team : teamList) {
-                if (groupService.isMember(authenticatedUser.getEmail(requestScope.getUser()), team.getName()) && team.isManageWorkspace())
-                    return true;
+                if (authenticatedUser.isServiceAccount(requestScope.getUser())) {
+                    if (groupService.isServiceMember(authenticatedUser.getApplication(requestScope.getUser()), team.getName())) {
+                        return true;
+                    }
+                } else {
+                    if (groupService.isMember(authenticatedUser.getEmail(requestScope.getUser()), team.getName()))
+                        return true;
+                }
             }
             return false;
         }
     }
+
 }

--- a/api/src/main/java/org/azbuilder/api/rs/job/Job.java
+++ b/api/src/main/java/org/azbuilder/api/rs/job/Job.java
@@ -26,7 +26,7 @@ public class Job extends GenericAuditFields {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
 
-    @UpdatePermission(expression = "team approve job OR user is a service")
+    @UpdatePermission(expression = "team approve job OR user is a super service")
     @Enumerated(EnumType.STRING)
     private JobStatus status = JobStatus.pending;
 
@@ -36,8 +36,8 @@ public class Job extends GenericAuditFields {
     @Column(name = "terraform_plan")
     private String terraformPlan;
 
-    @CreatePermission(expression = "user is a service")
-    @UpdatePermission(expression = "user is a service")
+    @CreatePermission(expression = "user is a super service")
+    @UpdatePermission(expression = "user is a super service")
     @Column(name = "approval_team")
     private String approvalTeam;
 
@@ -53,6 +53,7 @@ public class Job extends GenericAuditFields {
     @ManyToOne
     private Workspace workspace;
 
+    @UpdatePermission(expression = "user is a super service")
     @OneToMany(mappedBy = "job")
     private List<Step> step;
 

--- a/api/src/main/java/org/azbuilder/api/rs/module/Module.java
+++ b/api/src/main/java/org/azbuilder/api/rs/module/Module.java
@@ -21,9 +21,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-@ReadPermission(expression = "team view module OR user is a service")
+@ReadPermission(expression = "team view module")
 @CreatePermission(expression = "team manage module")
-@UpdatePermission(expression = "user is a service OR team manage module")
+@UpdatePermission(expression = "team manage module")
 @DeletePermission(expression = "team manage module")
 @Slf4j
 @Include(rootLevel = false)

--- a/api/src/main/java/org/azbuilder/api/rs/provider/Provider.java
+++ b/api/src/main/java/org/azbuilder/api/rs/provider/Provider.java
@@ -12,7 +12,7 @@ import javax.persistence.*;
 import java.util.List;
 import java.util.UUID;
 
-@ReadPermission(expression = "team view provider OR user is a service")
+@ReadPermission(expression = "team view provider")
 @CreatePermission(expression = "team manage provider")
 @UpdatePermission(expression = "team manage provider")
 @DeletePermission(expression = "team manage provider")

--- a/api/src/main/java/org/azbuilder/api/rs/template/Template.java
+++ b/api/src/main/java/org/azbuilder/api/rs/template/Template.java
@@ -10,7 +10,7 @@ import org.hibernate.annotations.Type;
 import javax.persistence.*;
 import java.util.UUID;
 
-@ReadPermission(expression = "team view template OR user is a service")
+@ReadPermission(expression = "team view template")
 @CreatePermission(expression = "team manage template")
 @UpdatePermission(expression = "team manage template")
 @DeletePermission(expression = "team manage template")

--- a/api/src/main/java/org/azbuilder/api/rs/vcs/Vcs.java
+++ b/api/src/main/java/org/azbuilder/api/rs/vcs/Vcs.java
@@ -14,7 +14,7 @@ import java.util.UUID;
 
 
 @Slf4j
-@ReadPermission(expression = "team view vcs OR user is a service")
+@ReadPermission(expression = "team view vcs")
 @CreatePermission(expression = "team manage vcs")
 @UpdatePermission(expression = "team manage vcs")
 @DeletePermission(expression = "team manage vcs")
@@ -42,16 +42,16 @@ public class Vcs extends GenericAuditFields {
     @Column(name = "client_id")
     private String clientId;
 
-    @ReadPermission(expression = "service read vcs secret")
+    @ReadPermission(expression = "read vcs secret")
     @Column(name = "client_secret")
     private String clientSecret;
 
-    @UpdatePermission(expression = "user is a service")
+    @UpdatePermission(expression = "user is a super service")
     @Enumerated(EnumType.STRING)
     @Column(name = "status")
     private VcsStatus status = VcsStatus.PENDING;
 
-    @ReadPermission(expression = "service read vcs secret")
+    @Exclude
     @Column(name = "access_token")
     private String accessToken;
 

--- a/api/src/main/java/org/azbuilder/api/rs/workspace/Workspace.java
+++ b/api/src/main/java/org/azbuilder/api/rs/workspace/Workspace.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.UUID;
 
 
-@ReadPermission(expression = "team view workspace OR user is a service")
+@ReadPermission(expression = "team view workspace")
 @CreatePermission(expression = "team manage workspace")
 @UpdatePermission(expression = "team manage workspace")
 @DeletePermission(expression = "team manage workspace")
@@ -52,7 +52,7 @@ public class Workspace {
     @OneToMany(mappedBy = "workspace")
     private List<Variable> variable;
 
-    @UpdatePermission(expression = "user is a service")
+    @UpdatePermission(expression = "user is a super service")
     @OneToMany(mappedBy = "workspace")
     private List<History> history;
 

--- a/api/src/main/java/org/azbuilder/api/rs/workspace/parameters/Variable.java
+++ b/api/src/main/java/org/azbuilder/api/rs/workspace/parameters/Variable.java
@@ -24,7 +24,7 @@ public class Variable {
     @Column(name="variable_key")
     private String key;
 
-    @ReadPermission(expression = "service read secret")
+    @ReadPermission(expression = "user read secret")
     @Column(name="variable_value")
     private String value;
 

--- a/api/src/test/java/org/azbuilder/api/VcsTests.java
+++ b/api/src/test/java/org/azbuilder/api/VcsTests.java
@@ -33,7 +33,6 @@ class VcsTests extends ServerApplicationTests{
                                         attributes(
                                                 attr("accessToken", "sampleToken"),
                                                 attr("clientId", "sampleId"),
-                                                attr("clientSecret", "sampleSecret"),
                                                 attr("createdBy", null),
                                                 attr("createdDate", null),
                                                 attr("description", "publicConnection"),

--- a/api/src/test/java/org/azbuilder/api/VcsTests.java
+++ b/api/src/test/java/org/azbuilder/api/VcsTests.java
@@ -31,7 +31,6 @@ class VcsTests extends ServerApplicationTests{
                                         type( "vcs"),
                                         id("0f21ba16-16d4-4ac7-bce0-3484024ee6bf"),
                                         attributes(
-                                                attr("accessToken", "sampleToken"),
                                                 attr("clientId", "sampleId"),
                                                 attr("createdBy", null),
                                                 attr("createdDate", null),

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>2.0.1</revision>
+        <revision>2.1.0</revision>
         <sonar.organization>azbuilder</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.project.key>AzBuilder_azb-server</sonar.project.key>


### PR DESCRIPTION
Allowing azure application to be part of an organization groups will allow client credentials authentication to be used in external integrations for examples:

- Bitbucket pipelines
- Azure DevOps pipelines
- Gitlab pipelines
- Github pipelines

Applications will be part of a group and will have the same level of access defined at team organization level when using client credentials authentication
