### PR TITLE
Fix tag registry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>2.4.3</revision>
+        <revision>2.4.4</revision>
         <sonar.organization>azbuilder</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.project.key>AzBuilder_azb-server</sonar.project.key>

--- a/registry/src/main/java/org/azbuilder/registry/service/git/GitServiceImpl.java
+++ b/registry/src/main/java/org/azbuilder/registry/service/git/GitServiceImpl.java
@@ -5,19 +5,23 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.transport.CredentialsProvider;
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 import org.springframework.stereotype.Service;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @Slf4j
 @Service
-public class GitServiceImpl implements GitService{
+public class GitServiceImpl implements GitService {
 
-    private static final String GIT_DIRECTORY="/.terraform-spring-boot/git/";
+    private static final String GIT_DIRECTORY = "/.terraform-spring-boot/git/";
 
     @Override
     public File getCloneRepositoryByTag(String repository, String tag, String vcsType, String accessToken) {
@@ -32,10 +36,12 @@ public class GitServiceImpl implements GitService{
             FileUtils.forceMkdir(gitCloneRepository);
             FileUtils.cleanDirectory(gitCloneRepository);
 
+            String correctTag = validateCorrectTag(tag, repository, setupCredentials(vcsType, accessToken));
+
             Git.cloneRepository()
                     .setURI(repository)
                     .setDirectory(gitCloneRepository)
-                    .setBranch("refs/tags/" + tag)
+                    .setBranch("refs/tags/" + correctTag)
                     .setCredentialsProvider(setupCredentials(vcsType, accessToken))
                     .call();
         } catch (GitAPIException | IOException ex) {
@@ -44,7 +50,7 @@ public class GitServiceImpl implements GitService{
         return gitCloneRepository;
     }
 
-    private CredentialsProvider setupCredentials(String vcsType, String accessToken){
+    private CredentialsProvider setupCredentials(String vcsType, String accessToken) {
         CredentialsProvider credentialsProvider = null;
         switch (vcsType) {
             case "GITHUB":
@@ -64,5 +70,28 @@ public class GitServiceImpl implements GitService{
                 break;
         }
         return credentialsProvider;
+    }
+
+    private String validateCorrectTag(String originalTag, String repository, CredentialsProvider credentialsProvider) {
+        List<String> versionList = new ArrayList<>();
+        String finalTag = originalTag;
+        Map<String, Ref> tags = null;
+        try {
+            tags = Git.lsRemoteRepository()
+                    .setTags(true)
+                    .setRemote(repository)
+                    .setCredentialsProvider(credentialsProvider)
+                    .callAsMap();
+        } catch (GitAPIException e) {
+            throw new RuntimeException(e);
+        }
+        tags.forEach((key, value) -> {
+            versionList.add(key.replace("refs/tags/", ""));
+        });
+
+        if (versionList.contains("v" + originalTag))
+            finalTag = "v" + originalTag;
+
+        return finalTag;
     }
 }


### PR DESCRIPTION
Validating if the remote repository is using tags that begins with "v" so the registry can import the module correctly

Example: 
 - https://github.com/terraform-aws-modules/terraform-aws-vpc
