### PR TITLE
Improving logic to cancel a running job

### DIFF
--- a/api/src/main/java/org/azbuilder/api/plugin/scheduler/ScheduleJobService.java
+++ b/api/src/main/java/org/azbuilder/api/plugin/scheduler/ScheduleJobService.java
@@ -72,4 +72,9 @@ public class ScheduleJobService {
         scheduler.deleteJob(new JobKey(PREFIX_JOB + triggerId));
     }
 
+    public void deleteJobContext(int jobId) throws ParseException, SchedulerException {
+        log.info("Delete Job Context {}", jobId);
+        scheduler.deleteJob(new JobKey(PREFIX_JOB_CONTEXT + jobId));
+    }
+
 }

--- a/api/src/main/java/org/azbuilder/api/rs/job/Job.java
+++ b/api/src/main/java/org/azbuilder/api/rs/job/Job.java
@@ -16,6 +16,7 @@ import javax.persistence.*;
 import java.util.List;
 
 @LifeCycleHookBinding(operation = LifeCycleHookBinding.Operation.CREATE, phase = LifeCycleHookBinding.TransactionPhase.POSTCOMMIT, hook = JobManageHook.class)
+@LifeCycleHookBinding(operation = LifeCycleHookBinding.Operation.UPDATE, phase = LifeCycleHookBinding.TransactionPhase.POSTCOMMIT, hook = JobManageHook.class)
 @Include(rootLevel = false)
 @Getter
 @Setter

--- a/api/src/main/java/org/azbuilder/api/rs/job/JobStatus.java
+++ b/api/src/main/java/org/azbuilder/api/rs/job/JobStatus.java
@@ -9,5 +9,6 @@ public enum JobStatus {
     completed,
 
     rejected,
-    cancelled
+    cancelled,
+    failed
 }


### PR DESCRIPTION
The following request will ***cancel*** a running job and will prevent all pending job steps to continue executing.
```
PATCH {{server}}/api/v1/organization/{{organizationId}}/job/{{jobId}}

{
  "data": {
    "type": "job",
    "id": "{{jobId}}",
    "attributes": {
      "status": "cancelled"
    }
  }
}
```
Improving these logic:
- When the job scheduler in the API checks the status ***cancelled*** it will mark all pending job steps as ***"cancelled"*** and delete the job context from quartz.
- When the executor finishes executing a job step it will validate if the status of the job is ***cancelled***

Limitation:
- Once the job is running inside the executor the [terraform spring boot starter](https://github.com/AzBuilder/terraform-spring-boot/issues/24) does not allow to cancel any terraform operation and release the block in the backend storage.
- The job step that is running wil be completed, for now it can not be completely cancelled.
